### PR TITLE
Il link S3 firmato si produce solo dietro autenticazione

### DIFF
--- a/MensaCore/main/api/cs/file_link.go
+++ b/MensaCore/main/api/cs/file_link.go
@@ -1,0 +1,149 @@
+package cs
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"mensadb/tools/cdnfiles"
+	"mensadb/tools/env"
+
+	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/list"
+)
+
+// defaultThumbSizes replica la costante omonima non esportata di
+// apis/file.go: PocketBase genera "100x100" per ogni campo file anche se non
+// e` dichiarata fra le thumbs. Se un giorno cambia la` va cambiata anche qui.
+var defaultThumbSizes = []string{"100x100"}
+
+// FileLinkHandler risponde a GET /api/cs/file-link e restituisce un link S3
+// firmato per un allegato.
+//
+// Esiste per i posti in cui un header non si puo` mandare: un PDF aperto in
+// Safari o in un visualizzatore di sistema, un file passato a un foglio di
+// condivisione, una pagina esterna. Li` l'app non puo` autenticare la
+// richiesta del file, ma puo` autenticare QUESTA: manda l'header, e solo se
+// l'header viene accettato riceve indietro il link firmato da consegnare a chi
+// aprira` il file.
+//
+// Due controlli, in quest'ordine:
+//
+//  1. `e.Auth == nil` -> 401. L'identita` la mettono i middleware globali, sia
+//     dal bearer OIDC di Zitadel sia da un token PocketBase nativo.
+//  2. la view rule della collection, valutata con l'identita` del chiamante.
+//     Senza, questo endpoint diventerebbe il modo piu` comodo per leggere gli
+//     allegati di record che l'utente non puo` vedere: PocketBase carica il
+//     record con FindRecordById, che le regole non le applica.
+//
+// Il secondo controllo e` piu` stretto di quello che PocketBase applica oggi
+// al download diretto, dove la view rule si guarda solo per i campi marcati
+// `protected` — cioe`, in questo schema, il solo `deals.attachment`.
+//
+// Parametri: `collection`, `record`, `file` e l'opzionale `thumb`. La chiave
+// S3 la si ricostruisce come fa PocketBase, cosi` il link punta esattamente
+// all'oggetto che servirebbe il download diretto.
+func FileLinkHandler(e *core.RequestEvent) error {
+	if e.Auth == nil {
+		return apis.NewUnauthorizedError("not authenticated", nil)
+	}
+
+	collectionName := strings.TrimSpace(e.Request.URL.Query().Get("collection"))
+	recordID := strings.TrimSpace(e.Request.URL.Query().Get("record"))
+	filename := strings.TrimSpace(e.Request.URL.Query().Get("file"))
+	if collectionName == "" || recordID == "" || filename == "" {
+		return apis.NewBadRequestError("collection, record and file are required", nil)
+	}
+
+	collection, err := e.App.FindCachedCollectionByNameOrId(collectionName)
+	if err != nil || collection == nil {
+		return apis.NewNotFoundError("", nil)
+	}
+
+	record, err := e.App.FindRecordById(collection, recordID)
+	if err != nil || record == nil {
+		return apis.NewNotFoundError("", nil)
+	}
+
+	// `filename` arriva dal client e finisce dentro una chiave S3: senza questo
+	// controllo un `../` la farebbe uscire dal prefisso del record. Il metodo
+	// risolve il nome fra i valori realmente salvati nel record, quindi
+	// qualunque cosa non sia un allegato di questo record non passa.
+	fileField := record.FindFileFieldByFile(filename)
+	if fileField == nil {
+		return apis.NewNotFoundError("", nil)
+	}
+
+	requestInfo, err := e.RequestInfo()
+	if err != nil {
+		return apis.NewBadRequestError("failed to load request info", err)
+	}
+	if ok, _ := e.App.CanAccessRecord(record, requestInfo, record.Collection().ViewRule); !ok {
+		// 404 e non 403, come fa PocketBase: dire "esiste ma non puoi" e` gia`
+		// dire qualcosa.
+		return apis.NewNotFoundError("", nil)
+	}
+
+	fileKey, err := resolveFileKey(e.App, record, fileField, filename, e.Request.URL.Query().Get("thumb"))
+	if err != nil {
+		return apis.NewNotFoundError("", err)
+	}
+
+	ttl := env.GetS3PresignTTL()
+	url := cdnfiles.GetFilePresignedURLWithTTL(e.App, e.App.Settings().S3.Bucket, fileKey, ttl)
+	if url == "" {
+		// S3 spento (sviluppo locale) o firma fallita. Non e` un errore per il
+		// client: il download diretto continua a funzionare, quindi gli si dice
+		// dove andare invece di lasciarlo senza niente.
+		return e.JSON(http.StatusOK, map[string]any{
+			"url":       e.App.Settings().Meta.AppURL + "/api/files/" + collection.Name + "/" + record.Id + "/" + filename,
+			"expiresAt": nil,
+			"signed":    false,
+		})
+	}
+
+	return e.JSON(http.StatusOK, map[string]any{
+		"url":       url,
+		"expiresAt": time.Now().Add(ttl).UTC().Format(time.RFC3339),
+		"signed":    true,
+	})
+}
+
+// resolveFileKey ricostruisce la chiave S3 dell'oggetto da firmare, con la
+// stessa logica di apis/file.go: l'originale sta in
+// `<collectionId>/<recordId>/<filename>`, la miniatura in
+// `<collectionId>/<recordId>/thumbs_<filename>/<size>_<filename>`.
+//
+// Sulle miniature si ricade sempre sull'originale quando non si puo` fare di
+// meglio — misura non dichiarata sul campo, oppure miniatura non ancora
+// generata. PocketBase le genera su richiesta durante il download; qui non si
+// serve niente, quindi firmare la chiave di una miniatura inesistente
+// darebbe un link che risponde 404 da S3.
+func resolveFileKey(app core.App, record *core.Record, fileField *core.FileField, filename, thumb string) (string, error) {
+	base := record.BaseFilesPath()
+	original := base + "/" + filename
+
+	thumb = strings.TrimSpace(thumb)
+	if thumb == "" {
+		return original, nil
+	}
+	if !list.ExistInSlice(thumb, defaultThumbSizes) && !list.ExistInSlice(thumb, fileField.Thumbs) {
+		return original, nil
+	}
+
+	fsys, err := app.NewFilesystem()
+	if err != nil {
+		return original, nil
+	}
+	defer func() {
+		_ = fsys.Close()
+	}()
+
+	thumbKey := base + "/thumbs_" + filename + "/" + thumb + "_" + filename
+	if exists, _ := fsys.Exists(thumbKey); exists {
+		return thumbKey, nil
+	}
+
+	return original, nil
+}

--- a/MensaCore/main/api/cs/load.go
+++ b/MensaCore/main/api/cs/load.go
@@ -33,6 +33,12 @@ func Load(e *router.RouterGroup[*core.RequestEvent]) {
 	e.DELETE("/passkeys/{id}", PasskeyDeleteHandler)
 
 	e.GET("/me", MeHandler)
+
+	// Link S3 firmato per un allegato, prodotto solo dietro header di
+	// autenticazione. Serve dove un header non si puo` mandare: PDF aperti in
+	// Safari o in un visualizzatore di sistema, fogli di condivisione, pagine
+	// esterne. Vedi FileLinkHandler.
+	e.GET("/file-link", FileLinkHandler)
 	e.POST("/send-update-notify", SendUpdateNotifyHandler)
 	e.GET("/force-update-addons", ForceUpdateAddonsHandler)
 	e.GET("/force-notification", forceNotification)

--- a/MensaCore/main/main.go
+++ b/MensaCore/main/main.go
@@ -93,7 +93,28 @@ func main() {
 		return e.Next()
 	})
 
+	// Il redirect 307 verso S3 consegna al chiamante un link firmato: una
+	// capability anonima che, fino alla scadenza, scarica il file senza header
+	// e senza passare piu` da qui. Prima lo si dava a chiunque conoscesse
+	// l'URL, con un'ora di validita`.
+	//
+	// Ora il link firmato si produce SOLO per una richiesta autenticata. `e.Auth`
+	// e` gia` valorizzato a questo punto da due middleware globali: quello
+	// Zitadel (zitadelauth.LoadAuth, registrato in OnServe) per il bearer OIDC
+	// che manda l'app, e il loader nativo di PocketBase per i token PB.
+	// Autenticarsi vuol dire quindi mandare l'header `Authorization`, ed e`
+	// l'header a decidere se il link firmato viene prodotto.
+	//
+	// Chi non si autentica non riceve un errore: si prosegue con `e.Next()` e
+	// il file lo serve PocketBase, con le stesse regole di sempre. Serve a non
+	// rompere cio` che un header non puo` mandarlo — le anteprime social di
+	// /links/event e /links/stamp, le versioni dell'app gia` installate, i
+	// player audio — mentre il link S3 smette di circolare.
 	app.OnFileDownloadRequest().BindFunc(func(e *core.FileDownloadRequestEvent) error {
+		if e.Auth == nil {
+			return e.Next()
+		}
+
 		s3settings := app.Settings().S3
 		presignedUrl := cdnfiles.GetFilePresignedURL(app, s3settings.Bucket, e.ServedPath)
 		if presignedUrl != "" {

--- a/MensaCore/tools/cdnfiles/get_file.go
+++ b/MensaCore/tools/cdnfiles/get_file.go
@@ -8,12 +8,30 @@ import (
 	"strings"
 	"time"
 
+	"mensadb/tools/env"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/pocketbase/pocketbase/core"
 )
 
+// GetFilePresignedURL firma un GET sull'oggetto S3 con la durata configurata
+// (S3_PRESIGN_TTL_SECONDS, default 5 minuti).
+//
+// Il valore che torna e` una capability anonima: chiunque lo possieda scarica
+// il file, senza header e senza passare piu` da PocketBase, fino alla
+// scadenza. Va consegnato solo a chi si e` gia` autenticato — vedi l'hook
+// OnFileDownloadRequest in main.go e l'endpoint /api/cs/file-link.
+//
+// Torna stringa vuota quando S3 e` spento o la firma fallisce: chi chiama deve
+// trattarlo come "nessun link" e ricadere sullo streaming di PocketBase.
 func GetFilePresignedURL(app core.App, bucket, fileKey string) string {
+	return GetFilePresignedURLWithTTL(app, bucket, fileKey, env.GetS3PresignTTL())
+}
+
+// GetFilePresignedURLWithTTL e` la variante con durata esplicita, per i
+// chiamanti che hanno una finestra propria da rispettare.
+func GetFilePresignedURLWithTTL(app core.App, bucket, fileKey string, ttl time.Duration) string {
 	s3settings := app.Settings().S3
 	if s3settings.Enabled {
 		s3client, err := NewS3(s3settings.Region, s3settings.Endpoint, s3settings.AccessKey, s3settings.Secret, s3settings.ForcePathStyle)
@@ -27,7 +45,7 @@ func GetFilePresignedURL(app core.App, bucket, fileKey string) string {
 				Bucket: aws.String(bucket),
 				Key:    aws.String(fileKey),
 			},
-			s3.WithPresignExpires(time.Hour))
+			s3.WithPresignExpires(ttl))
 		if err != nil {
 			app.Logger().Error("create s3 presigned url", "error", err)
 			return ""

--- a/MensaCore/tools/env/init.go
+++ b/MensaCore/tools/env/init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/caarlos0/env/v11"
 )
@@ -64,6 +65,15 @@ type config struct {
 	// Lasciarlo vuoto in produzione: ogni fingerprint elencato qui puo`
 	// richiedere le passkey del nostro relying party.
 	AndroidDebugSHA256 string `env:"ANDROID_DEBUG_SHA256" envDefault:""`
+	// Durata in secondi dei link S3 firmati che serviamo per immagini e
+	// documenti. Un link firmato e` una capability anonima: chi ce l'ha
+	// scarica il file senza passare piu` da noi, quindi la sua durata e` la
+	// finestra in cui un link finito in un log, in un Referer o in una chat
+	// resta spendibile. Stava a un'ora fissa nel codice; il default e` ora
+	// cinque minuti, che basta per aprire un PDF o caricare una lista di
+	// immagini. In env perche` un CDN davanti a noi puo` volere finestre piu`
+	// larghe, e non si cambia una policy di sicurezza con una release.
+	S3PresignTTLSeconds int `env:"S3_PRESIGN_TTL_SECONDS" envDefault:"300"`
 }
 
 var cfg = config{}
@@ -133,6 +143,18 @@ func MustValidate() error {
 
 func GetPasswordUUID() string {
 	return cfg.PasswordUUID
+}
+
+// GetS3PresignTTL e` la durata dei link S3 firmati.
+//
+// Un valore non positivo in env verrebbe accettato da AWS come "gia` scaduto"
+// e romperebbe ogni download senza un errore leggibile: in quel caso si torna
+// al default di cinque minuti invece di fidarsi della configurazione.
+func GetS3PresignTTL() time.Duration {
+	if cfg.S3PresignTTLSeconds <= 0 {
+		return 5 * time.Minute
+	}
+	return time.Duration(cfg.S3PresignTTLSeconds) * time.Second
 }
 
 func GetPasswordSalt() string {


### PR DESCRIPTION
## Il problema

L'hook `OnFileDownloadRequest` in `main/main.go` rispondeva **a chiunque** con un `307` verso un link S3 presigned valido **un'ora**.

Quel link è una capability anonima: una volta ottenuto scarica il file senza header e senza passare più dal backend, e si può rigirare a chiunque. Bastava conoscere `collection/recordId/filename` — e in questo schema quasi tutti i campi file hanno `protected = false`, quindi PocketBase non guarda nemmeno le view rule (`apis/file.go` carica il record con `FindRecordById`, che le regole non le applica).

Concretamente: chiunque avesse un URL `/api/files/documents/<id>/<file>` otteneva in cambio un link S3 anonimo, spendibile per 60 minuti, che restava nei log, nel `Referer` e nella history di qualunque proxy.

## Cosa cambia

**Il link firmato si produce solo per una richiesta autenticata.** A quel punto della catena `e.Auth` è già valorizzato dai due middleware globali — `zitadelauth.LoadAuth()` per il bearer OIDC che manda l'app, il loader nativo di PocketBase per i token PB — quindi autenticarsi vuol dire mandare l'header `Authorization`, ed è l'header a decidere se il link viene prodotto.

Verificato nel sorgente di `pocketbase@v0.37.4`: `BuildMux()` viene chiamata dentro il trigger di `OnServe`, cioè **dopo** il nostro `e.Router.Bind(...)`, e `loadMux` propaga i middleware del gruppo radice a ogni rotta figlia — compresa `/api/files/{collection}/{recordId}/{filename}`.

**Chi non si autentica non riceve un errore.** Si prosegue con `e.Next()` e il file lo serve PocketBase con le regole di sempre. È deliberato: serve a non rompere ciò che un header non può mandarlo — le anteprime social di `/links/event` e `/links/stamp`, le versioni dell'app già installate, i player audio. Cambia chi riceve il link S3, non chi riceve il file.

**`GET /api/cs/file-link`** è il pezzo per i posti dove l'header non si può mandare ma si può autenticare la richiesta *del link*: PDF aperti nel visualizzatore di sistema, fogli di condivisione, pagine esterne. Manda l'header, ricevi il link firmato da consegnare a chi aprirà il file. Controlla anche la view rule della collection con l'identità del chiamante — più stretto del download diretto, che la guarda solo per i campi `protected`. `filename` viene risolto con `FindFileFieldByFile`, quindi non può uscire dal prefisso del record.

**La durata scende da un'ora fissa nel codice a cinque minuti configurabili** (`S3_PRESIGN_TTL_SECONDS`). È la finestra in cui un link finito in un log o in una chat resta spendibile; per confronto, il file token nativo di PocketBase dura 180 secondi.

## Verifica

- `go build ./...` e `go vet ./...` puliti.
- Il comportamento per le richieste anonime è identico a prima: stesso path di serving, stesse regole.

## Note per chi rivede

Tre cose emerse guardando lo schema, **non toccate** in questa PR perché sono cambiamenti rompenti che vanno pianificati a parte:

1. `deals.attachment` è l'unico campo con `protected = true`, ma i client costruiscono quell'URL senza `?token=` → **404 silenzioso oggi**. La funzione allegati dei deal è probabilmente rotta.
2. Le misure thumb che i client chiedono (`200x200`, `800x0`, `1200x0`) **non sono dichiarate** in nessun campo file: le uniche dichiarate sono `0x50`, `0x100`, `0x250`, `0x500`. PocketBase ricade in silenzio sull'originale — cioè l'app scarica il file pieno credendo di scaricare una miniatura. Il commento in `FilesUrl.kt` dice che quelle misure "vanno dichiarate lato server": non lo sono mai state.
3. Quattro view pubbliche (`view_local_office`, `view_local_office_admins`, `view_local_office_assistants`, `view_local_office_linktree`) clonano campi file da `local_offices.image` e `members_registry.image` con view rule vuota. Restano un bypass anche se un giorno quei campi diventassero `protected`.

## Rilascio

Il merge su `main` fa partire da solo la catena Lint → Security → Build → Notify, cioè il redeploy. Conviene che questo vada **prima** dell'app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDu9Dvseo4pYjrUnQBedPa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDu9Dvseo4pYjrUnQBedPa)_