### PR TITLE
Interruttore di config per il link S3 dietro autenticazione (cutover-safe)

### DIFF
--- a/MensaCore/main/main.go
+++ b/MensaCore/main/main.go
@@ -110,8 +110,15 @@ func main() {
 	// rompere cio` che un header non puo` mandarlo — le anteprime social di
 	// /links/event e /links/stamp, le versioni dell'app gia` installate, i
 	// player audio — mentre il link S3 smette di circolare.
+	// Il gate su e.Auth e` sotto un interruttore di config (FILE_LINK_REQUIRE_AUTH,
+	// default true). A false il link firmato torna a chiunque, per mettere in
+	// produzione questa immagine con la stessa resa della vecchia durante il
+	// cutover e riattivare la protezione da config quando l'app aggiornata e`
+	// diffusa. Nota: il gate non nega mai il file — a true una richiesta anonima
+	// non fa 404, cade su e.Next() e il file lo serve PocketBase; cambia solo se
+	// i byte li offloada S3 o li serve il backend. Vedi env.GetFileLinkRequireAuth.
 	app.OnFileDownloadRequest().BindFunc(func(e *core.FileDownloadRequestEvent) error {
-		if e.Auth == nil {
+		if env.GetFileLinkRequireAuth() && e.Auth == nil {
 			return e.Next()
 		}
 

--- a/MensaCore/tools/env/init.go
+++ b/MensaCore/tools/env/init.go
@@ -74,6 +74,44 @@ type config struct {
 	// immagini. In env perche` un CDN davanti a noi puo` volere finestre piu`
 	// larghe, e non si cambia una policy di sicurezza con una release.
 	S3PresignTTLSeconds int `env:"S3_PRESIGN_TTL_SECONDS" envDefault:"300"`
+	// FileLinkRequireAuth decide chi riceve il link S3 firmato (307) sul
+	// download diretto, nell'hook OnFileDownloadRequest.
+	//
+	//   true  (default) — il link firmato si produce solo per una richiesta
+	//                     autenticata (header Authorization). Le richieste
+	//                     anonime cadono su e.Next() e il file lo serve
+	//                     PocketBase, in streaming dal backend.
+	//   false           — il link firmato va a chiunque, come prima di
+	//                     settembre 2026: si riapre il buco (il link S3 e`
+	//                     una capability anonima che circola), ma il carico
+	//                     torna a essere offloadato a S3.
+	//
+	// ATTENZIONE a cosa NON fa. Il flag non nega mai un file: a `true` una
+	// richiesta anonima NON riceve un 404, riceve gli stessi byte serviti dal
+	// backend invece del redirect a S3. Quindi non evita "rotture" — nessun
+	// consumatore anonimo che oggi vede un file smette di vederlo. Quello che
+	// cambia e` DOVE passano i byte: a `true` ogni richiesta senza header
+	// (app vecchie, crawler delle anteprime social, player audio) la serve il
+	// backend invece di S3. L'unica conseguenza reale e` l'egress sul backend.
+	//
+	// Esiste per il cutover verso l'app che manda l'header anche sui download
+	// di file (mensa_italia_app v22.2.8). Finche` la stragrande maggioranza
+	// delle installazioni e` la vecchia app, che l'header non lo manda, `true`
+	// significa servire dal backend quasi tutto il traffico immagini. La
+	// sequenza sensata: tira su l'immagine nuova con `false` (stessa resa
+	// della vecchia su chi-riceve-il-link e su offload a S3), aspetta che la
+	// nuova app si diffonda sugli store, poi alza a `true`. Reversibile da
+	// config, senza redeploy.
+	//
+	// NON e` un ripristino byte-per-byte della vecchia immagine: `false` da
+	// solo tocca solo questo gate. Restano le altre modifiche della stessa
+	// release, ortogonali a questo flag — il TTL del link firmato (5 min di
+	// default, era 1 ora; si allunga con S3_PRESIGN_TTL_SECONDS) e l'endpoint
+	// additivo GET /api/cs/file-link, che le app vecchie non chiamano.
+	//
+	// Il default e` `true`: un'immagine tirata su senza toccare la config e`
+	// quella sicura, non quella comoda.
+	FileLinkRequireAuth bool `env:"FILE_LINK_REQUIRE_AUTH" envDefault:"true"`
 }
 
 var cfg = config{}
@@ -155,6 +193,13 @@ func GetS3PresignTTL() time.Duration {
 		return 5 * time.Minute
 	}
 	return time.Duration(cfg.S3PresignTTLSeconds) * time.Second
+}
+
+// GetFileLinkRequireAuth dice se il link S3 firmato sul download diretto va
+// prodotto solo dietro autenticazione (true, sicuro e default) o per chiunque
+// (false, comportamento storico per il cutover). Vedi il campo omonimo.
+func GetFileLinkRequireAuth() bool {
+	return cfg.FileLinkRequireAuth
 }
 
 func GetPasswordSalt() string {


### PR DESCRIPTION
## Perche'

La #18 ha chiuso il link S3 firmato dietro autenticazione. Il gate e' assoluto: appena l'immagine e' in produzione, ogni richiesta di file **senza** header `Authorization` smette di ricevere il 307 verso S3 e viene servita in streaming dal backend. Le installazioni sono oggi quasi tutte la **vecchia** app, che quell'header non lo manda (lo aggiunge solo la v22.2.8, non ancora diffusa sugli store): deployare cosi' sposta di colpo quasi tutto il traffico immagini sul backend.

Serviva un modo per **mettere in produzione questa immagine senza cambiare comportamento**, e attivare la protezione dopo, quando l'app aggiornata e' diffusa — **senza redeploy**.

## Cosa fa

Un flag di config sull'hook `OnFileDownloadRequest`:

```go
if env.GetFileLinkRequireAuth() && e.Auth == nil {
    return e.Next()
}
```

| `FILE_LINK_REQUIRE_AUTH` | comportamento |
|---|---|
| `true` (default) | link firmato solo dietro autenticazione (comportamento #18, sicuro) |
| `false` | link firmato a chiunque (come prima di settembre 2026); offload a S3 come la vecchia immagine |

Il `&&` va in corto quando il flag e' `false`, quindi l'hook percorre byte-per-byte il ramo pre-#18. Il default e' `true`: un'immagine tirata su senza toccare la config e' quella sicura.

## Sequenza di cutover

1. Deploy immagine nuova con **`FILE_LINK_REQUIRE_AUTH=false`** → stessa resa della vecchia, zero sorprese, zero shift di banda.
2. Attendi che **v22.2.8** (che manda l'header sui download) si diffonda sugli store.
3. Alza a **`true`** → la protezione si attiva; solo il traffico davvero anonimo cade sul backend.
4. Se qualcosa va storto, torna a **`false`** da config. Nessun redeploy.

## Cosa il flag NON fa — verificato, non asserito

Un workflow di verifica adversarial su tre lenti, sul codice vendorizzato di PocketBase v0.37.4, ha corretto due punti che avevo dato per scontati:

- **Il flag non nega mai un file.** A `true` una richiesta anonima non riceve un 404: cade su `e.Next()` e il file lo serve PocketBase. Cambia solo **dove passano i byte** (S3 vs backend). Quindi non previene "rotture" — nessun consumatore anonimo che oggi vede un file smette di vederlo (anteprime social `/links/event` e `/links/stamp`, player audio, avatar, immagini SIG/deal: tutti campi non-`protected`, serviti comunque). L'unica conseguenza reale e' **l'egress sul backend**.
- **`deals.attachment` non e' una regressione di questo cambiamento.** Il check dei campi `protected` gira in `apis/file.go:108-125` **prima** che l'hook scatti (`file.go:197`): il suo comportamento e' identico immagine vecchia/nuova a qualsiasi valore del flag. Il flag e' a valle del gate `protected` e non lo tocca.
- **`e.Auth` e' popolato per entrambi i canali** al momento dell'hook: bearer Zitadel (`zitadelauth.LoadAuth`, root middleware in OnServe) e token PB nativo (`loadAuthToken`). Il `/files` route ha come unico middleware di rotta un rate limiter, nessun auth loader posticipato. Nessuna richiesta autenticata via header arriva all'hook con `e.Auth` nil.

## Ortogonale al flag

`false` da solo ripristina **solo questo gate**. Le altre modifiche di #18 sono indipendenti: il TTL del link (5 min, era 1 ora — regolabile con `S3_PRESIGN_TTL_SECONDS`) e l'endpoint additivo `GET /api/cs/file-link` (che le app vecchie non chiamano). Per la resa esatta della vecchia immagine: `false` + `S3_PRESIGN_TTL_SECONDS=3600`.

## Verifica

- `caarlos0/env/v11` parsa il bool come atteso: assente→`true`, `false`/`0`→`false`, `true`/`1`→`true` (provato con un binario standalone sul modulo reale).
- `go build ./...`, `go vet ./...`, `golangci-lint` v2.11.4 → **0 issues**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)