### PR TITLE
Default di FILE_LINK_PUBLIC_COLLECTIONS, e un titolo per le anteprime dei francobolli

### DIFF
--- a/MensaCore/tools/env/file_link_test.go
+++ b/MensaCore/tools/env/file_link_test.go
@@ -1,0 +1,53 @@
+package env
+
+import "testing"
+
+// Il default di FILE_LINK_PUBLIC_COLLECTIONS non e` una comodita`: decide cosa
+// resta raggiungibile senza autenticazione quando l'immagine parte senza
+// config. Sbagliarlo in un verso lascia scoperti i dati dei soci, nell'altro
+// spegne in silenzio le anteprime social e i player audio — e in nessuno dei
+// due casi qualcosa diventa rosso. Da qui questo test.
+func TestDefaultPublicCollections(t *testing.T) {
+	// Riservate: contengono dati dei soci e devono restare dietro
+	// autenticazione anche senza config.
+	for _, name := range []string{
+		"documents", "members_registry", "users", "deals", "sigs", "events_schedule",
+	} {
+		if IsFileLinkPublicCollection(name) {
+			t.Errorf("%q non deve essere pubblica per default", name)
+		}
+	}
+
+	// Pubbliche: hanno gia` viewRule vuota nello schema, e i loro consumatori
+	// un header non possono mandarlo.
+	for _, name := range []string{
+		"events", "stamp", "podcasts", "podcast_episodes",
+		"quid_articles_audio", "ex_apps", "addons", "local_offices",
+	} {
+		if !IsFileLinkPublicCollection(name) {
+			t.Errorf("%q deve restare pubblica per default", name)
+		}
+	}
+}
+
+// L'hook passa nome E id della collection: basta che uno dei due sia
+// nell'elenco. Un id vuoto non deve far passare niente.
+func TestPublicCollectionMatchesNameOrID(t *testing.T) {
+	if !IsFileLinkPublicCollection("stamp", "pbc_123") {
+		t.Error("il match sul nome deve bastare")
+	}
+	if IsFileLinkPublicCollection("documents", "") {
+		t.Error("una collection riservata non deve passare per via dell'id vuoto")
+	}
+	if IsFileLinkPublicCollection("", "") {
+		t.Error("nome e id vuoti non devono mai passare")
+	}
+}
+
+// Il gate e` acceso per default: un'immagine tirata su senza config e` quella
+// che protegge, non quella comoda.
+func TestRequireAuthDefaultsOn(t *testing.T) {
+	if !GetFileLinkRequireAuth() {
+		t.Error("FILE_LINK_REQUIRE_AUTH deve essere true per default")
+	}
+}

--- a/MensaCore/tools/env/init.go
+++ b/MensaCore/tools/env/init.go
@@ -98,11 +98,28 @@ type config struct {
 	// collection (nome o id) i cui file restano scaricabili senza
 	// autenticazione anche con FILE_LINK_REQUIRE_AUTH=true. Per queste il
 	// comportamento e` quello storico: link S3 firmato a chiunque, o file dal
-	// backend se S3 e` spento. Serve per i consumatori che un header non
-	// possono mandarlo (es. le immagini di eventi e stamp nelle anteprime
-	// social di /links/event e /links/stamp). Vuoto di default: nessuna
-	// eccezione finche` non la si dichiara.
-	FileLinkPublicCollections string `env:"FILE_LINK_PUBLIC_COLLECTIONS" envDefault:""`
+	// backend se S3 e` spento.
+	//
+	// Il default NON e` vuoto, ed e` una scelta: le collection elencate qui
+	// hanno gia` `viewRule = ""` nello schema, cioe` sono pubbliche per decisione
+	// nostra. Metterle dietro autenticazione non protegge niente che non fosse
+	// gia` leggibile via /api/collections, e in compenso rompe i consumatori che
+	// un header non possono mandarlo:
+	//
+	//   events, stamp          anteprime social di /links/event e /links/stamp
+	//                          (il crawler di Telegram/WhatsApp non ha sessione)
+	//   podcasts,              audio dato ad ExoPlayer e AVPlayer, che scaricano
+	//   podcast_episodes,      per conto loro e con range request lunghe quanto
+	//   quid_articles_audio    l'ascolto: un link firmato scadrebbe a meta'
+	//   ex_apps, addons        icone dell'area pubblica, mostrate prima del login
+	//   local_offices          immagini delle sedi, viewRule pubblica
+	//
+	// Restano dietro autenticazione le collection che contengono dati dei soci:
+	// documents, members_registry, users, deals, sigs, events_schedule.
+	//
+	// Un'immagine tirata su senza toccare la config si comporta quindi cosi':
+	// gli allegati riservati chiusi, il resto come prima.
+	FileLinkPublicCollections string `env:"FILE_LINK_PUBLIC_COLLECTIONS" envDefault:"events,stamp,podcasts,podcast_episodes,quid_articles_audio,ex_apps,addons,local_offices"`
 }
 
 var cfg = config{}


### PR DESCRIPTION
Segue [#18](https://github.com/Mensa-Italia/mensa_online/pull/18) e `ecccb0a`, che ha portato il download anonimo a rispondere 404.

---

# 1. Il default vuoto spegneva mezza app

Con il 404 attivo, `FILE_LINK_PUBLIC_COLLECTIONS` è ciò che decide cosa resta raggiungibile senza autenticazione. Era **vuoto di default**, quindi un'immagine tirata su senza toccare la config chiude anche ciò che è pubblico per scelta nostra e che un header non può mandarlo:

| cosa | perché si rompe |
|---|---|
| anteprime social di `/links/event` e `/links/stamp` | il crawler di Telegram/WhatsApp non ha una sessione: `og:image` → 404 |
| audio podcast e narrazioni Quid | li scaricano ExoPlayer e AVPlayer per conto loro |
| icone area pubblica (`ex_apps`, `addons`) e immagini sedi | mostrate prima del login |

Sull'audio va detto che **un link firmato non basterebbe comunque**: le range request di un player durano quanto l'ascolto, molto più dei cinque minuti di `S3_PRESIGN_TTL_SECONDS`, e la firma viene validata a ogni richiesta. Un podcast da 40 minuti si interromperebbe a metà.

Il default elenca ora le collection che hanno già `viewRule = ""` nello schema — verificato su `baseline_schema.json` e sulle migration Go:

```
events, stamp, podcasts, podcast_episodes,
quid_articles_audio, ex_apps, addons, local_offices
```

Metterle dietro autenticazione non protegge niente che non fosse già leggibile da `/api/collections`: sposta il buco altrove e rompe qualcosa per strada. **Restano chiuse** quelle che contengono dati dei soci: `documents`, `members_registry`, `users`, `deals`, `sigs`, `events_schedule`.

---

# 2. Le anteprime dei francobolli uscivano senza titolo

`LinksStamps` leggeva il titolo da `record.GetString("name")`, ma la collection `stamp` un campo `name` non ce l'ha — solo `id`, `image`, `description`, `created`, `updated`. Tornava sempre stringa vuota, quindi ogni anteprima social di un francobollo usciva con `<title>` e `og:title` vuoti: su Telegram e WhatsApp un riquadro con l'immagine e nessuna riga di testo.

Il testo sta in `description`, che ora fa da titolo, con un fallback generico se manca anche quello. `events` un campo `name` ce l'ha davvero, quindi `links/events.go` va già bene e non si tocca.

È venuto fuori indagando perché lo scanner dei timbri rifiutasse i QR — vedi [Mensa-Italia/mensa_italia_app#225](https://github.com/Mensa-Italia/mensa_italia_app/pull/225), dove sta il grosso di quel guasto.

---

## Verifica

- `go build ./...`, `go vet ./...`, `go test ./tools/env/` — tutti verdi.
- I test coprono l'elenco delle collection pubbliche. Sbagliarlo in un verso lascia scoperti i dati dei soci, nell'altro spegne in silenzio anteprime e audio: in nessuno dei due casi qualcosa diventa rosso da solo, ed è il motivo per cui un test qui serve.

## Nota

`ecccb0a` ha reso il gate un vero rifiuto — ed è la cosa giusta, il mio `e.Next()` originale lasciava il file leggibile a chiunque. Il costo però è che ogni consumatore senza header smette di funzionare nello stesso istante, e i client non erano pronti.

Conviene che questa vada in produzione **prima o insieme** all'app, non dopo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDu9Dvseo4pYjrUnQBedPa