### PR TITLE
Le anteprime dei francobolli escono con un titolo

### DIFF
--- a/MensaCore/main/links/stamp.go
+++ b/MensaCore/main/links/stamp.go
@@ -242,9 +242,19 @@ func LinksStamps(e *core.RequestEvent) error {
 
 	imageKey := record.BaseFilesPath() + "/" + record.GetString("image")
 
+	// La collection `stamp` un campo `name` non ce l'ha — solo id, image,
+	// description, created, updated. `GetString("name")` tornava quindi sempre
+	// stringa vuota, e ogni anteprima social di un francobollo usciva senza
+	// titolo: <title> vuoto e og:title vuoto. Il testo del francobollo sta in
+	// `description`, che qui fa da titolo.
+	title := record.GetString("description")
+	if title == "" {
+		title = "Francobollo Mensa Italia"
+	}
+
 	data := StampTemplateData{
 		Id:          idStamp,
-		Title:       record.GetString("name"),
+		Title:       title,
 		Description: record.GetString("description"),
 		Image:       "https://svc.mensa.it/api/files/" + imageKey,
 		URL:         "https://svc.mensa.it/links/stamp/" + idStamp,


### PR DESCRIPTION
Questo commit era arrivato sul branch subito dopo il merge di [#21](https://github.com/Mensa-Italia/mensa_online/pull/21), quindi è rimasto fuori. Riproposto sopra il main aggiornato.

## Il problema

`LinksStamps` leggeva il titolo da `record.GetString("name")`, ma la collection `stamp` un campo `name` non ce l'ha — solo `id`, `image`, `description`, `created`, `updated`. Tornava quindi sempre stringa vuota, e ogni anteprima social di un francobollo usciva con `<title>` e `og:title` vuoti: su Telegram e WhatsApp un riquadro con l'immagine e nessuna riga di testo.

Il testo del francobollo sta in `description`, che ora fa da titolo, con un fallback generico se manca anche quello — un'anteprima senza nessun testo non è un'anteprima.

`events` un campo `name` ce l'ha davvero, quindi `links/events.go` va già bene e non si tocca.

## Come è saltato fuori

Indagando perché lo scanner dei timbri rifiutasse i QR. Il grosso di quel guasto era lato app ([Mensa-Italia/mensa_italia_app#226](https://github.com/Mensa-Italia/mensa_italia_app/pull/226)); questa è la parte server che è emersa leggendo lo schema di `stamp`.

## Verifica

`go build ./...`, `go vet ./...`, `go test ./tools/env/` — tutti verdi sopra il main attuale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDu9Dvseo4pYjrUnQBedPa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JDu9Dvseo4pYjrUnQBedPa)_